### PR TITLE
Add persistence for filters, sorting and col layout

### DIFF
--- a/banknote-tabulator.js
+++ b/banknote-tabulator.js
@@ -195,6 +195,11 @@ function loadInventory() {
             {title:"URL", field:"url", headerFilter: true, formatter: "link"},
         ],
         movableColumns: true,
+        persistence: {
+            sort: true,
+            headerFilter: true,
+            columns: true,
+        },
     });
 
     table.on("rowClick", rowClickHandler);


### PR DESCRIPTION
As per the tabulator doc — https://tabulator.info/docs/5.5/persist — stores stuff in localStorage if available, then in cookies.

I'd prefer URL for sharing state but not going to implement it.
