### PR TITLE
Adjust to CloudFlare-related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ To create venv:
 To refresh inventory:
 `.venv/bin/python3 download-products.py`
 
+Optionally set the delay in seconds between HTTP requests:
+`.venv/bin/python3 download-products.py --delay=20`
+
 ### DevContainer-based
 
 `.devcontainer/devcontainer.json` contains a `postCreateCommand` that will attempt to download and unpack database archive from production instance to avoid doing a full scrape.

--- a/download-products.py
+++ b/download-products.py
@@ -120,7 +120,7 @@ for item in sorted(product_index, key=itemgetter('article')):
 
     # Old frontend template (before Oct 9 2024)
     leasing_item = soup.find('product-item-leasing')
-    if leasing_item.has_attr(':product'):
+    if leasing_item != None and leasing_item.has_attr(':product'):
         product_data = leasing_item[':product']
     else:
         # New frontend template (since Oct 9 2024)

--- a/download-products.py
+++ b/download-products.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from product import Product
 from banknote import Banknote
 import sentry_sdk
+import sys
 
 
 # Init Sentry before doing anything that might raise exception
@@ -31,7 +32,6 @@ except:
 
 # Keep cache of entire inventory in RAM
 product_index = []
-
 
 # Define inventory file storage paths
 root = pathlib.Path(__file__).parent.resolve()
@@ -57,6 +57,9 @@ def download_index():
     print(f"Downloading page:", end='', flush=True)
     for page_number in range(2, last_page_number+1):
         print(f" #{page_number}", end='', flush=True)
+        if delay > 0:
+            print(f"... ", end='', flush=True)
+            time.sleep(delay)
         r = requests.get('https://veikals.banknote.lv/lv/filter-products', params={'categories': 8, 'page': page_number})
         extra_page = r.json()
         product_index.extend(extra_page['data'])
@@ -119,8 +122,9 @@ for item in sorted(product_index, key=itemgetter('article')):
     item_file_path = product.create_new_filename()
     print(f"Fetching {item['url']}...")
     
-    print(f"Sleeping for {delay} seconds to avoid blocking")
-    time.sleep(delay)
+    if delay > 0:
+        print(f"Sleeping for {delay} seconds to avoid blocking")
+        time.sleep(delay)
 
     r = requests.get(item['url'], allow_redirects=False)
     if r.status_code == 301:

--- a/download-products.py
+++ b/download-products.py
@@ -38,6 +38,12 @@ root = pathlib.Path(__file__).parent.resolve()
 folder = os.path.join(root, "inventory")
 inventory = Banknote(folder)
 
+# get delay in seconds from cli options, like "--delay=20", default = 15
+delay = 15
+for arg in sys.argv:
+    if arg.startswith("--delay="):
+        delay = int(arg.split("=")[1])
+
 def download_index():
     print("Downloading first page...")
     # https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
@@ -112,6 +118,10 @@ for item in sorted(product_index, key=itemgetter('article')):
     product.ensure_path_exists()
     item_file_path = product.create_new_filename()
     print(f"Fetching {item['url']}...")
+    
+    print(f"Sleeping for {delay} seconds to avoid blocking")
+    time.sleep(delay)
+
     r = requests.get(item['url'], allow_redirects=False)
     if r.status_code == 301:
         print(f"Redirected to {r.headers['Location']}, removing from index")

--- a/download-products.py
+++ b/download-products.py
@@ -125,6 +125,10 @@ for item in sorted(product_index, key=itemgetter('article')):
     else:
         # New frontend template (since Oct 9 2024)
         buy_now_btn = soup.find('buy-now-btn')
+        if buy_now_btn == None:
+            print(f"Page for {item['id']} has no info, probably sold, removing from index")
+            product_index.remove(item)
+            continue
         product_data = buy_now_btn[':product']
 
     if product_data:

--- a/download-products.py
+++ b/download-products.py
@@ -114,7 +114,8 @@ for item in sorted(product_index, key=itemgetter('article')):
     print(f"Fetching {item['url']}...")
     r = requests.get(item['url'], allow_redirects=False)
     if r.status_code == 301:
-        print(f"Redirected to {r.headers['Location']}, skipping")
+        print(f"Redirected to {r.headers['Location']}, removing from index")
+        product_index.remove(item)
         continue
     html_contents = r.text
     soup = BeautifulSoup(html_contents, 'html.parser')

--- a/download-products.py
+++ b/download-products.py
@@ -112,7 +112,10 @@ for item in sorted(product_index, key=itemgetter('article')):
     product.ensure_path_exists()
     item_file_path = product.create_new_filename()
     print(f"Fetching {item['url']}...")
-    r = requests.get(item['url'])
+    r = requests.get(item['url'], allow_redirects=False)
+    if r.status_code == 301:
+        print(f"Redirected to {r.headers['Location']}, skipping")
+        continue
     html_contents = r.text
     soup = BeautifulSoup(html_contents, 'html.parser')
 


### PR DESCRIPTION
Looks like they renamed some classes, perhaps it's time to retire the old UI parsing logic.

- Fix parsing product if the old selector is not found
- Skip pages with no info — items could be marked sold but still appear on the index
- Skip redirects — most likely CF attempts to throw you into an endless loop
- Add optional `--delay=15` to the downloader
