### PR TITLE
Add support for params from URL

### DIFF
--- a/banknote-tabulator.js
+++ b/banknote-tabulator.js
@@ -323,6 +323,19 @@ function loadInventory(categoryName) {
 
     document.getElementById("resetFiltersButton").onclick = function(){
         table.clearFilter(true);
+
+        if (window.location.search) {
+            var url = new URL(window.location.href);
+            var currentParams = new URLSearchParams(window.location.search);
+            // It skips one param without toArray() 🤷
+            for (const [key] of currentParams.entries().toArray()) {
+                if (key.startsWith("headerFilter")) {
+                    currentParams.delete(key);
+                }
+            }
+            url.search = currentParams.toString();
+            window.history.pushState({}, "", url);
+        }
     }
 }
 

--- a/banknote-tabulator.js
+++ b/banknote-tabulator.js
@@ -336,7 +336,13 @@ function switchMenu(categoryName) {
     var categoryMenu = document.getElementById("category-menu");
     var element = categoryMenu.children[categoryNames.indexOf(categoryName)];
 
-    window.history.pushState({}, "", element.getAttribute("href"));
+    // construct the URL with category from selected category + current query parameters
+    var url = new URL(window.location.origin + element.getAttribute("href"));
+    var currentParams = new URLSearchParams(window.location.search);
+    currentParams.set('category', categoryName);
+    url.search = currentParams.toString();
+
+    window.history.pushState({}, "", url);
     for (var i = 0; i < categoryMenu.children.length; i++) {
         categoryMenu.children[i].classList.remove("active");
     }
@@ -357,7 +363,10 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    var category = (new URLSearchParams(window.location.search)).get('category');
+    var category = null;
+    if (window.location.search) {
+        category = (new URLSearchParams(window.location.search)).get('category');
+    }
     if (category === null) {
         category = categoryNames[0];
     }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
         <script type="text/javascript" src="banknote-tabulator.js"></script>
-        <link href="style.css" rel="stylesheet"">
+        <link href="style.css" rel="stylesheet">
     </head>
     <body>
         <div class="menu-container">


### PR DESCRIPTION
- Fix quotes in html
- Add support for params from URL, don't persist them
- Don't lose the filter immediately after load, also lets ir stay after switching categories
- Clear params from URL when resetting filters with the button

Use case: I want to have two tabulators open with different filtering criteria.

Tested only with header filters, no idea how it impacts other options tbh,
didn't see anything weird yet.
