### PR TITLE
Add number comparison filter to relevant fields

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: node tests/numeric-filters.js

--- a/banknote-tabulator.js
+++ b/banknote-tabulator.js
@@ -2,14 +2,16 @@ var numericFilterExpressionCache = {};
 var numericRowValueCache = {};
 
 function numericColumn(title, field) {
+    var isCapacityCol = ["ram", "storage"].includes(field);
     return {
         title: title,
         field: field,
         headerFilter: true,
         headerFilterFunc: numericTextFilterFunc,
         headerFilterFuncParams: {
-            parseCapacity: ["ram", "storage"].includes(field),
+            parseCapacity: isCapacityCol,
         },
+        headerTooltip: "Try >, >=, <, <=, =" + (isCapacityCol ? "; expects GB" : "")
     };
 }
 

--- a/banknote-tabulator.js
+++ b/banknote-tabulator.js
@@ -1,10 +1,134 @@
+var numericFilterExpressionCache = {};
+var numericRowValueCache = {};
+
+function numericColumn(title, field) {
+    return {
+        title: title,
+        field: field,
+        headerFilter: true,
+        headerFilterFunc: numericTextFilterFunc,
+        headerFilterFuncParams: {
+            parseCapacity: ["ram", "storage"].includes(field),
+        },
+    };
+}
+
+function parseNumericValue(value) {
+    return parseFloat(String(value).replace(",", "."));
+}
+
+function normalizeCapacityToGb(value, unit) {
+    var numberValue = parseNumericValue(value);
+    var unitName = (unit || "").toLowerCase();
+
+    if (["gb", "g", "гб", "gб"].includes(unitName)) {
+        return numberValue;
+    }
+
+    if (["tb", "t", "tб", "тб", "tr"].includes(unitName)) {
+        return numberValue * 1024;
+    }
+
+    // only mb left
+    return numberValue / 1024;
+}
+
+function parseCapacityValue(value) {
+    var rawValue = String(value);
+    var capacityRegex = /([+-]?\d+(?:[.,]\d+)?)\s*(gb|gб|tb|mb|гб|тб|tб|tr|[gt](?=\s|$|[^a-zа-яё]))/gi;
+    var capacities = [];
+    var match;
+
+    while ((match = capacityRegex.exec(rawValue)) !== null) {
+        var capacity = normalizeCapacityToGb(match[1], match[2]);
+
+        if (!Number.isNaN(capacity)) {
+            capacities.push(capacity);
+        }
+    }
+
+    if (capacities.length > 0) {
+        return Math.max(...capacities);
+    }
+
+    // plain number, nothing else
+    if (/^\s*[+-]?\d+(?:[.,]\d+)?\s*$/.test(rawValue)) {
+        return parseNumericValue(rawValue);
+    }
+
+    // mid trash like "512 SSD", no GB
+    var storageMatch = rawValue.match(/(?:([+-]?\d+(?:[.,]\d+)?)\s*(?:ssd|hdd)\b|(?:ssd|hdd)\D+([+-]?\d+(?:[.,]\d+)?))/i);
+    if (storageMatch) {
+        return parseNumericValue(storageMatch[1] || storageMatch[2]);
+    }
+
+    // deliberately not handling complete trash like "asdf512ghjkl"
+    return null;
+}
+
+function numericFilterExpression(headerValue, filterParams) {
+    var rawValue = String(headerValue || "").trim();
+    var cacheKey = (filterParams.parseCapacity ? "capacity:" : "plain:") + rawValue;
+
+    if (Object.prototype.hasOwnProperty.call(numericFilterExpressionCache, cacheKey)) {
+        return numericFilterExpressionCache[cacheKey];
+    }
+
+    var expression = null;
+    var expressionMatch = rawValue.match(/^(>=|<=|>|<|=)\s*([+-]?\d+)$/);
+    if (expressionMatch) {
+        expression = {
+            operator: expressionMatch[1],
+            value: parseNumericValue(expressionMatch[2]),
+        };
+    }
+    numericFilterExpressionCache[cacheKey] = expression;
+
+    return expression;
+}
+
+function parseNumericRowValue(rowValue, filterParams) {
+    if (rowValue === null || rowValue === undefined) {
+        return null;
+    }
+
+    var rawValue = String(rowValue);
+    var cacheKey = (filterParams.parseCapacity ? "capacity:" : "plain:") + rawValue;
+
+    if (Object.prototype.hasOwnProperty.call(numericRowValueCache, cacheKey)) {
+        return numericRowValueCache[cacheKey];
+    }
+
+    numericRowValueCache[cacheKey] = filterParams.parseCapacity
+        ? parseCapacityValue(rawValue)
+        : parseNumericValue(rawValue);
+
+    return numericRowValueCache[cacheKey];
+}
+
+function numericTextFilterFunc(headerValue, rowValue, rowData, filterParams) {
+    var expression = numericFilterExpression(headerValue, filterParams);
+
+    if (!expression) {
+        return Tabulator.moduleBindings.filter.filters.like(headerValue, rowValue, rowData, filterParams);
+    }
+
+    var numericRowValue = parseNumericRowValue(rowValue, filterParams);
+
+    if (numericRowValue === null || Number.isNaN(numericRowValue)) {
+        return false;
+    }
+
+    return Tabulator.moduleBindings.filter.filters[expression.operator](expression.value, numericRowValue, rowData, filterParams);
+}
+
 var categories = [
     {
         "name": "laptops",
         "columns": [
             {title: "CPU", field: "cpu", headerFilter: true},
-            {title: "RAM", field: "ram", headerFilter: true},
-            {title: "Storage", field: "storage", headerFilter: true},
+            numericColumn("RAM", "ram"),
+            numericColumn("Storage", "storage"),
             {title: "GPU", field: "gpu", headerFilter: true}
         ]
     },
@@ -12,8 +136,8 @@ var categories = [
         "name": "desktops",
         "columns": [
             {title: "CPU", field: "cpu", headerFilter: true},
-            {title: "RAM", field: "ram", headerFilter: true},
-            {title: "Storage", field: "storage", headerFilter: true},
+            numericColumn("RAM", "ram"),
+            numericColumn("Storage", "storage"),
             {title: "GPU", field: "gpu", headerFilter: true},
             {title: "OS", field: "os", headerFilter: true},
             {title: "Motherboard", field: "motherboard", headerFilter: true}
@@ -23,8 +147,8 @@ var categories = [
         "name": "monitors",
         "columns": [
             {title: "Resolution", field: "resolution", headerFilter: true},
-            {title: "Size", field: "size", headerFilter: true},
-            {title: "Refresh rate", field: "refresh_rate", headerFilter: true},
+            numericColumn("Size", "size"),
+            numericColumn("Refresh rate", "refresh_rate"),
             {title: "Panel", field: "panel", headerFilter: true}
         ]
     }

--- a/tests/numeric-filters.js
+++ b/tests/numeric-filters.js
@@ -1,0 +1,89 @@
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const tabulatorFilters = {
+    "=": function(filterVal, rowVal) { return rowVal == filterVal; },
+    "<": function(filterVal, rowVal) { return rowVal < filterVal; },
+    "<=": function(filterVal, rowVal) { return rowVal <= filterVal; },
+    ">": function(filterVal, rowVal) { return rowVal > filterVal; },
+    ">=": function(filterVal, rowVal) { return rowVal >= filterVal; },
+    like: function(filterVal, rowVal) {
+        if (filterVal === null || typeof filterVal === "undefined") {
+            return rowVal === filterVal;
+        }
+
+        if (typeof rowVal !== "undefined" && rowVal !== null) {
+            return String(rowVal).toLowerCase().indexOf(filterVal.toLowerCase()) > -1;
+        }
+
+        return false;
+    },
+};
+
+const context = {
+    console: console,
+    document: {addEventListener: function() {}},
+    window: {},
+    Tabulator: {
+        moduleBindings: {
+            filter: {filters: tabulatorFilters},
+        },
+    },
+};
+context.globalThis = context;
+
+vm.createContext(context);
+vm.runInContext(fs.readFileSync("banknote-tabulator.js", "utf8"), context);
+
+function assertEqual(name, actual, expected) {
+    if (actual !== expected) {
+        throw new Error(name + ": expected " + expected + ", got " + actual);
+    }
+}
+
+function resetCaches() {
+    context.numericFilterExpressionCache = {};
+    context.numericRowValueCache = {};
+}
+
+resetCaches();
+
+const capacityParams = {parseCapacity: true};
+const storageParams = {parseCapacity: true};
+const genericParams = {};
+
+[
+    ["RAM parses GB", context.parseNumericRowValue("8 GB", capacityParams), 8],
+    ["RAM parses compact GB", context.parseNumericRowValue("16GB", capacityParams), 16],
+    ["RAM ignores DDR prefix", context.parseNumericRowValue("DDR4 16GB", capacityParams), 16],
+    ["RAM ignores multiplier prefix", context.parseNumericRowValue("2x8GB DDR4", capacityParams), 8],
+    ["RAM converts MB", context.parseNumericRowValue("8192 MB", capacityParams), 8],
+    ["RAM parses Cyrillic GB", context.parseNumericRowValue("16 ГБ Память", capacityParams), 16],
+    ["Storage parses TB", context.parseNumericRowValue("1 TB SSD", storageParams), 1024],
+    ["Storage parses T shorthand", context.parseNumericRowValue("3T SSD", storageParams), 3072],
+    ["Storage parses decimal TB", context.parseNumericRowValue("1.5 TB SSD (1 TB NVMe + 500 GB NVMe)", storageParams), 1536],
+    ["Storage parses TBGB typo as TB", context.parseNumericRowValue("1TBGB SSD", storageParams), 1024],
+    ["Storage parses G shorthand", context.parseNumericRowValue("128G SSD", storageParams), 128],
+    ["Storage parses Cyrillic TB/GB", context.parseNumericRowValue("HDD 1 TБ/ SSD 256 ГБ", storageParams), 1024],
+    ["Storage ignores Gen4 before TB", context.parseNumericRowValue("NVMe PCIe Gen4 SSD 1TB", storageParams), 1024],
+    ["Storage ignores model numbers", context.parseNumericRowValue("Samsung SSD 970 EVO Plus 250GB", storageParams), 250],
+    ["Storage picks largest capacity", context.parseNumericRowValue("256 GB SSD, 1 TB HDD", storageParams), 1024],
+    ["Storage does not sum mirrored notation", context.parseNumericRowValue("2x 512GB SSD", storageParams), 512],
+    ["Storage parses bare number before SSD", context.parseNumericRowValue("512 SSD", storageParams), 512],
+    ["Storage parses bare number after SSD", context.parseNumericRowValue("SSD 256", storageParams), 256],
+    ["Storage rejects typo unit HB", context.parseNumericRowValue("512HB SSD", storageParams), null],
+    ["Storage rejects model without capacity", context.parseNumericRowValue("Optiarc DVD RW AD-7280S", storageParams), null],
+    ["Generic size still parses first number", context.parseNumericRowValue("27\"", genericParams), 27],
+    ["Generic refresh still parses first number", context.parseNumericRowValue("144 Hz", genericParams), 144],
+].forEach(function(testCase) {
+    assertEqual(testCase[0], testCase[1], testCase[2]);
+});
+
+assertEqual(">8 excludes 8GB", context.numericTextFilterFunc(">8", "8 GB", null, capacityParams), false);
+assertEqual(">=8 includes 8GB", context.numericTextFilterFunc(">=8", "8 GB", null, capacityParams), true);
+assertEqual(">1000 includes 1TB", context.numericTextFilterFunc(">1000", "1 TB SSD", null, storageParams), true);
+assertEqual("plain 8 uses text fallback", context.numericTextFilterFunc("8", "18 GB", null, capacityParams), true);
+assertEqual("unit query is not numeric syntax", context.numericTextFilterFunc(">1tb", "1536 GB", null, storageParams), false);
+assertEqual("decimal query is not numeric syntax", context.numericTextFilterFunc(">1.5", "2 GB", null, capacityParams), false);
+
+console.log("ok");

--- a/tests/numeric-filters.js
+++ b/tests/numeric-filters.js
@@ -2,12 +2,12 @@ const fs = require("node:fs");
 const vm = require("node:vm");
 
 const tabulatorFilters = {
-    "=": function(filterVal, rowVal) { return rowVal == filterVal; },
-    "<": function(filterVal, rowVal) { return rowVal < filterVal; },
-    "<=": function(filterVal, rowVal) { return rowVal <= filterVal; },
-    ">": function(filterVal, rowVal) { return rowVal > filterVal; },
-    ">=": function(filterVal, rowVal) { return rowVal >= filterVal; },
-    like: function(filterVal, rowVal) {
+    "=": (filterVal, rowVal) => rowVal == filterVal,
+    "<": (filterVal, rowVal) => rowVal < filterVal,
+    "<=": (filterVal, rowVal) => rowVal <= filterVal,
+    ">": (filterVal, rowVal) => rowVal > filterVal,
+    ">=": (filterVal, rowVal) => rowVal >= filterVal,
+    like: (filterVal, rowVal) => {
         if (filterVal === null || typeof filterVal === "undefined") {
             return rowVal === filterVal;
         }
@@ -22,7 +22,7 @@ const tabulatorFilters = {
 
 const context = {
     console: console,
-    document: {addEventListener: function() {}},
+    document: {addEventListener: () => {}},
     window: {},
     Tabulator: {
         moduleBindings: {
@@ -35,16 +35,16 @@ context.globalThis = context;
 vm.createContext(context);
 vm.runInContext(fs.readFileSync("banknote-tabulator.js", "utf8"), context);
 
-function assertEqual(name, actual, expected) {
+const assertEqual = (name, actual, expected) => {
     if (actual !== expected) {
         throw new Error(name + ": expected " + expected + ", got " + actual);
     }
-}
+};
 
-function resetCaches() {
+const resetCaches = () => {
     context.numericFilterExpressionCache = {};
     context.numericRowValueCache = {};
-}
+};
 
 resetCaches();
 
@@ -75,7 +75,7 @@ const genericParams = {};
     ["Storage rejects model without capacity", context.parseNumericRowValue("Optiarc DVD RW AD-7280S", storageParams), null],
     ["Generic size still parses first number", context.parseNumericRowValue("27\"", genericParams), 27],
     ["Generic refresh still parses first number", context.parseNumericRowValue("144 Hz", genericParams), 144],
-].forEach(function(testCase) {
+].forEach((testCase) => {
     assertEqual(testCase[0], testCase[1], testCase[2]);
 });
 

--- a/tests/numeric-filters.js
+++ b/tests/numeric-filters.js
@@ -41,12 +41,10 @@ const assertEqual = (name, actual, expected) => {
     }
 };
 
-const resetCaches = () => {
-    context.numericFilterExpressionCache = {};
-    context.numericRowValueCache = {};
-};
 
-resetCaches();
+// reset caches
+context.numericFilterExpressionCache = {};
+context.numericRowValueCache = {};
 
 const capacityParams = {parseCapacity: true};
 const storageParams = {parseCapacity: true};


### PR DESCRIPTION
It's been a bit of a pain to look for computers with min/max gigs, so here we are. RAM and storage values are normalized to GB.

<img width="314" height="394" alt="image" src="https://github.com/user-attachments/assets/dcc8ee42-c37b-48ea-bdf8-7b1d50c426cb" />

The edge case of `8 GB (konfigurējams līdz 1234)` is not handled atm, not sure if needed.

The logic may eventually travel to prices too as is, or with ranges, but out of scope for now.

Since banknote data is trash, it was a fair hassle to check all combos, so I also added - *gasp!* - tests, and a pipeline to run them. Feel free to nuke it if you wish.
